### PR TITLE
Extract typesec, funcsec, *and* codesec from prebuilt module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 as_files := $(wildcard assembly/*.ts)
+scripts := $(wildcard scripts/*.ts)
 
 .PHONY: bundle
-bundle: build/release.wasm
+bundle: prebuilt-wasm
 	npx tsc
 	npx vite build
 
 .PHONY: prebuilt-wasm
-prebuilt-wasm: build/release.wasm
+prebuilt-wasm: build/release.wasm_sections.ts
+
+build/release.wasm_sections.ts: build/release.wasm $(scripts)
+	npx ts-node --esm scripts/bundlewasm.ts
 
 build/release.wasm: $(as_files)
 	npx asc assembly/index.ts --target release --runtime stub -O0 --noExportMemory
-	npx ts-node --esm scripts/bundlewasm.ts

--- a/scripts/bundlewasm.ts
+++ b/scripts/bundlewasm.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs"
-import { extractCodesec } from "./extractCodesec.ts"
+import { extractFunctions } from "./extractFunctions.ts"
 
 /*
   Extracts the code section from the AssemblyScript release build
@@ -8,20 +8,27 @@ import { extractCodesec } from "./extractCodesec.ts"
 
 const inputPath = "../build/release.wasm"
 const inputUrl = new URL(inputPath, import.meta.url)
-const outputUrl = new URL(inputPath + "_codesec.ts", import.meta.url)
+const outputUrl = new URL(inputPath + "_sections.ts", import.meta.url)
 
 const buf = fs.readFileSync(inputUrl)
-const { entryCount, contents } = extractCodesec(buf)
+const sections = extractFunctions(buf)
 
-const base64Contents = JSON.stringify(Buffer.from(contents).toString("base64"))
-const output = `const bytes = atob(${base64Contents});
-const buf = new Uint8Array(bytes.length);
-for (let i = 0; i < bytes.length; i++) {
-  buf[i] = bytes.charCodeAt(i);
-}
-export default {
-  entryCount: ${JSON.stringify(entryCount)},
-  contents: buf
-}
+let output = ""
+for (const [secName, { entryCount, contents }] of Object.entries(sections)) {
+  const base64Contents = JSON.stringify(
+    Buffer.from(contents).toString("base64"),
+  )
+  output += `export const ${secName} = (() => {
+  const bytes = atob(${base64Contents});
+  const buf = new Uint8Array(bytes.length);
+  for (let i = 0; i < bytes.length; i++) {
+    buf[i] = bytes.charCodeAt(i);
+  }
+  return {
+    entryCount: ${JSON.stringify(entryCount)},
+    contents: Array.from(buf)
+  }
+})()
 `
+}
 fs.writeFileSync(outputUrl, output, "utf8")

--- a/scripts/extractFunctions.ts
+++ b/scripts/extractFunctions.ts
@@ -19,7 +19,8 @@ export type VecContents = {
   contents: Uint8Array
 }
 
-function getModuleFunctions(bytes: Uint8Array) {
+// Extracts the type, function, and code sections from a Wasm module.
+export function extractFunctions(bytes: Uint8Array) {
   checkPreamble(bytes)
 
   function peekSectionId(): number {
@@ -65,7 +66,7 @@ function getModuleFunctions(bytes: Uint8Array) {
   }
 
   let typesec: VecContents | undefined = undefined
-  let functionsec: VecContents | undefined = undefined
+  let funcsec: VecContents | undefined = undefined
   let codesec: VecContents | undefined = undefined
 
   let pos = 8
@@ -83,7 +84,7 @@ function getModuleFunctions(bytes: Uint8Array) {
     if (id === 1) {
       typesec = parseSectionOpaque(id)
     } else if (id === 3) {
-      functionsec = parseSectionOpaque(id)
+      funcsec = parseSectionOpaque(id)
     } else if (id === 10) {
       codesec = parseSectionOpaque(id)
     } else {
@@ -92,13 +93,7 @@ function getModuleFunctions(bytes: Uint8Array) {
   }
   return {
     typesec: checkNotNull(typesec),
-    functionsec: checkNotNull(functionsec),
+    funcsec: checkNotNull(funcsec),
     codesec: checkNotNull(codesec),
   }
-}
-
-// Extracts the code section from the Wasm module in `bytes`.
-export function extractCodesec(bytes: Uint8Array): VecContents {
-  const { codesec } = getModuleFunctions(bytes)
-  return codesec
 }

--- a/src/core/wasm/mod.ts
+++ b/src/core/wasm/mod.ts
@@ -3,16 +3,14 @@ import * as w from "@wasmgroundup/emit"
 import { checkNotNull } from "../assert"
 import { BuiltinFunction } from "./builtins"
 
-import prebuiltCodesec from "../../../build/release.wasm_codesec"
+import * as prebuilt from "../../../build/release.wasm_sections"
+
+// https://webassembly.github.io/spec/core/bikeshed/index.html#sections%E2%91%A0
+const SECTION_ID_TYPE = 1;
+const SECTION_ID_FUNCTION = 3;
+const SECTION_ID_CODE = 10;
 
 const WASM_PAGE_SIZE = 65536
-
-// Signature for the externally-defined `optimize` function.
-// TODO: Parse this from the prebuilt module.
-const OPTIMIZE_FUNCTYPE = w.functype(
-  [w.valtype.i32, w.valtype.i32, w.valtype.f64, w.valtype.f64, w.valtype.f64],
-  [],
-)
 
 interface WasmFunction {
   name: string
@@ -20,10 +18,26 @@ interface WasmFunction {
   body: w.BytecodeFragment
 }
 
+interface PrebuiltSection {
+  entryCount: number
+  contents: number[]
+}
+
+// Produce a code section combining `codeEls` with the prebuilt code.
+// Note that funcidxs are not rewritten, so the types
+function mergeSections(sectionId: number, prebuilt: PrebuiltSection, els: w.BytecodeFragment) {
+  const count = prebuilt.entryCount + els.length
+  return w.section(sectionId, [
+    w.u32(count),
+    prebuilt.contents,
+    els,
+  ])
+}
+
 // Wasm modules have a separate section for function types, and function
 // declarations use an index into that section.
 // This creates a mapping from function type to typeidx.
-function functypeIndex(types: w.BytecodeFragment[]) {
+function functypeIndex(types: w.BytecodeFragment[], startIdx: number) {
   const typeToString = (t: w.BytecodeFragment) => JSON.stringify(t)
 
   const typeidxByString = new Map<string, number>()
@@ -41,7 +55,7 @@ function functypeIndex(types: w.BytecodeFragment[]) {
     // Return the typeidx for the given type `t`.
     typeidx(t: w.BytecodeFragment): w.BytecodeFragment {
       const idx = checkNotNull(typeidxByString.get(typeToString(t)))
-      return w.typeidx(idx)
+      return w.typeidx(idx + startIdx)
     },
     // Return a valid typesec for the module.
     typesec() {
@@ -56,14 +70,9 @@ export function instantiateModule(
   memory: WebAssembly.Memory,
 ) {
   const functypes = functypeIndex([
-    // This must be the first recorded type — it's implicitly used for any
-    // `call_indirect` in the prebuilt AssemblyScript code.
-    // TODO: Find a cleaner way to do this.
-    w.functype([], [w.valtype.f64]),
     ...builtinFunctions.map(({ type }) => type),
     ...functions.map(({ type }) => type),
-    OPTIMIZE_FUNCTYPE,
-  ])
+  ], prebuilt.typesec.entryCount)
 
   const imports = builtinFunctions.map(({ name, type }) => {
     const typeIdx = functypes.typeidx(type)
@@ -80,36 +89,22 @@ export function instantiateModule(
 
   // Go from a "user" function index (0: loss function, 1...n: gradients)
   // to the actual index in the module.
-  const userFuncIdx = (idx: number) => builtinFunctions.length + idx
+  const userFuncIdx = (idx: number) => builtinFunctions.length + prebuilt.codesec.entryCount + idx
 
   const exports: w.BytecodeFragment = []
   functions.forEach(({ name }, i) => {
     if (name) exports.push(w.export_(name, w.exportdesc.func(userFuncIdx(i))))
   })
   // Export the externally-defined `optimize` function.
+  // TODO: Look up the correct index in the prebuilt module.
   exports.push(
-    w.export_("optimize", w.exportdesc.func(userFuncIdx(functions.length))),
+    w.export_("optimize", w.exportdesc.func(userFuncIdx(-1))),
   )
 
-  const funcsec = [
-    ...functions.map(({ type }) => functypes.typeidx(type)),
-    functypes.typeidx(OPTIMIZE_FUNCTYPE),
-  ]
-
-  // Produce a code section combining `codeEls` with the prebuilt code.
-  const codesecWithPrebuilt = (codeEls: w.BytecodeFragment) => {
-    const count = prebuiltCodesec.entryCount + codeEls.length
-    return w.section(10, [
-      w.u32(count),
-      codeEls,
-      Array.from(prebuiltCodesec.contents),
-    ])
-  }
-
   const fragment = w.module([
-    w.typesec(functypes.typesec()),
+    mergeSections(SECTION_ID_TYPE, prebuilt.typesec, functypes.typesec()),
     w.importsec(imports),
-    w.funcsec(funcsec),
+    mergeSections(SECTION_ID_FUNCTION, prebuilt.funcsec, functions.map(({ type }) => functypes.typeidx(type))),
     w.tablesec([
       w.table(w.tabletype(w.elemtype.funcref, w.limits.min(functions.length))),
     ]),
@@ -122,7 +117,7 @@ export function instantiateModule(
         functions.map((_, i) => w.funcidx(userFuncIdx(i))),
       ),
     ]),
-    codesecWithPrebuilt(
+    mergeSections(SECTION_ID_CODE, prebuilt.codesec,
       functions.map(({ body }) => w.code(w.func([], [...body, w.instr.end]))),
     ),
   ])


### PR DESCRIPTION
Previously, we extracted only the code section from the prebuilt module, and hardcoded the type and function declaration.

This PR makes it so that the typesec and funcsec are copied from the prebuilt module. This is a step towards supporting an arbitrary number of prebuilt functions, not just one.