### PR TITLE
Refactor optimize to allow observations to be passed in

### DIFF
--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,10 +1,12 @@
-export type { Num, Param } from "./types"
 export type { AnyNum } from "./num"
+export type { Optimizer } from "./optimize"
+export type { Num, Param } from "./types"
+
 export { param, observation, zero, one, nodeCount } from "./construct"
 export { tex } from "./tex"
 export { evaluator } from "./eval"
 export { gradient } from "./grad"
-export { optimize } from "./optimize"
+export { optimize, optimizer } from "./optimize"
 export {
   num,
   add,

--- a/src/core/optimize.ts
+++ b/src/core/optimize.ts
@@ -1,4 +1,4 @@
-import { assert, checkNotNull } from "./assert"
+import { assert } from "./assert"
 import * as e from "./eval"
 import * as g from "./grad"
 import { collectParams } from "./params"
@@ -62,7 +62,7 @@ export function optimizer(loss: t.Num, init?: Map<t.Param, number>): Optimizer {
         .filter((p) => p.fixed)
         .forEach((p) => {
           assert(
-            !!checkNotNull(observations.get(p)),
+            !!observations.get(p),
             `missing value for observation '${p.name}'`,
           )
         })

--- a/src/core/optimize.ts
+++ b/src/core/optimize.ts
@@ -1,43 +1,76 @@
+import { assert, checkNotNull } from "./assert"
 import * as e from "./eval"
 import * as g from "./grad"
-import { wasmOptimizer } from "./wasmopt"
+import { collectParams } from "./params"
 import * as t from "./types"
+import { wasmOptimizer } from "./wasmopt"
 
 const useWasm = true
+
+export interface Optimizer {
+  optimize(iterations: number, observations?: Map<t.Param, number>): e.Evaluator
+}
+
+function basicOptimizer(loss: t.Num, gradient: Map<t.Param, t.Num>) {
+  return (
+    freeParams: Map<t.Param, number>,
+    observations: Map<t.Param, number>,
+    iterations: number,
+  ) => {
+    const params = new Map([...freeParams, ...observations])
+    const epsilon = 0.0001
+    let i = iterations
+    while (i > 0) {
+      const ev = e.evaluator(params)
+      const l = ev.evaluate(loss)
+      if (i % 1000 == 0) {
+        console.log(l)
+      }
+      gradient.forEach((v, k) => {
+        const diff = ev.evaluate(v)
+        const old = params.get(k) || 0
+        const update = old - diff * epsilon
+        params.set(k, update)
+      })
+      i = i - 1
+    }
+    return params.entries()
+  }
+}
+
+export function optimizer(loss: t.Num, init?: Map<t.Param, number>): Optimizer {
+  const gradient = g.gradient(loss)
+
+  let optimizeImpl = (useWasm ? wasmOptimizer : basicOptimizer)(loss, gradient)
+
+  // Ensure that all the free params have an initial value.
+  const freeParams = new Map(init)
+  gradient.forEach((_, k) => {
+    if (!freeParams.has(k)) freeParams.set(k, Math.random() * 10)
+  })
+
+  return {
+    optimize(iterations: number, observations = new Map<t.Param, number>()) {
+      // Ensure we have a value for all fixed parameters.
+      collectParams(loss)
+        .filter((p) => p.fixed)
+        .forEach((p) => {
+          assert(
+            !!checkNotNull(observations.get(p)),
+            `missing value for observation '${p.name}'`,
+          )
+        })
+
+      const newParams = optimizeImpl(freeParams, observations, iterations)
+      return e.evaluator(new Map(newParams))
+    },
+  }
+}
 
 export function optimize(
   loss: t.Num,
   init: Map<t.Param, number>,
   iterations: number,
 ): e.Evaluator {
-  const gradient = g.gradient(loss)
-  const params = new Map(init)
-  gradient.forEach((_, k) => {
-    if (!params.has(k)) params.set(k, Math.random() * 10)
-  })
-
-  if (useWasm) {
-    const { optimize } = wasmOptimizer(loss, gradient, params)
-    const newParams = optimize(iterations)
-    return e.evaluator(newParams)
-  }
-
-  const epsilon = 0.0001
-  let i = iterations
-  while (i > 0) {
-    const ev = e.evaluator(params)
-    const l = ev.evaluate(loss)
-    if (i % 1000 == 0) {
-      console.log(l)
-    }
-    gradient.forEach((v, k) => {
-      const diff = ev.evaluate(v)
-      const old = params.get(k) || 0
-      const update = old - diff * epsilon
-      params.set(k, update)
-    })
-    i = i - 1
-  }
-
-  return e.evaluator(params)
+  return optimizer(loss, init).optimize(iterations)
 }

--- a/src/core/optimize.ts
+++ b/src/core/optimize.ts
@@ -71,6 +71,7 @@ export function optimize(
   loss: t.Num,
   init: Map<t.Param, number>,
   iterations: number,
+  observations?: Map<t.Param, number>
 ): e.Evaluator {
-  return optimizer(loss, init).optimize(iterations)
+  return optimizer(loss, init).optimize(iterations, observations)
 }

--- a/src/core/optimize.ts
+++ b/src/core/optimize.ts
@@ -47,6 +47,8 @@ export function optimizer(loss: t.Num, init?: Map<t.Param, number>): Optimizer {
     if (!freeParams.has(k)) freeParams.set(k, Math.random() * 10)
   })
 
+  // The internal interface for optimizers is basically the same as the public
+  // API, but implementations can assume that param values are fully specified.
   let optimizeImpl = (useWasm ? wasmOptimizer : basicOptimizer)(
     loss,
     gradient,

--- a/src/core/optimize.ts
+++ b/src/core/optimize.ts
@@ -14,10 +14,10 @@ export interface Optimizer {
 function basicOptimizer(
   loss: t.Num,
   gradient: Map<t.Param, t.Num>,
-  freeParams: Map<t.Param, number>,
+  init: Map<t.Param, number>,
 ) {
   return (iterations: number, observations: Map<t.Param, number>) => {
-    const params = new Map([...freeParams, ...observations])
+    const params = new Map([...init, ...observations])
     const epsilon = 0.0001
     let i = iterations
     while (i > 0) {

--- a/src/core/optimize.ts
+++ b/src/core/optimize.ts
@@ -43,7 +43,7 @@ export function optimizer(loss: t.Num, init?: Map<t.Param, number>): Optimizer {
 
   let optimizeImpl = (useWasm ? wasmOptimizer : basicOptimizer)(loss, gradient)
 
-  // Ensure that all the free params have an initial value.
+  // Ensure that we have an initial value for all free parameters.
   const freeParams = new Map(init)
   gradient.forEach((_, k) => {
     if (!freeParams.has(k)) freeParams.set(k, Math.random() * 10)
@@ -51,7 +51,7 @@ export function optimizer(loss: t.Num, init?: Map<t.Param, number>): Optimizer {
 
   return {
     optimize(iterations: number, observations = new Map<t.Param, number>()) {
-      // Ensure we have a value for all fixed parameters.
+      // Ensure that we have a value for all fixed parameters.
       collectParams(loss)
         .filter((p) => p.fixed)
         .forEach((p) => {

--- a/src/core/params.ts
+++ b/src/core/params.ts
@@ -1,7 +1,7 @@
 import { assertUnreachable } from "./assert"
 import * as t from "./types"
 
-export function collectParams(root: t.Num): Set<t.Param> {
+export function collectParams(root: t.Num): t.Param[] {
   const params = new Set<t.Param>()
   const visited = new Set<t.Num>()
 
@@ -39,5 +39,5 @@ export function collectParams(root: t.Num): Set<t.Param> {
 
   visitNum(root)
 
-  return params
+  return Array.from(params)
 }

--- a/src/core/wasmopt.test.ts
+++ b/src/core/wasmopt.test.ts
@@ -7,9 +7,8 @@ import * as g from "./grad"
 import { wasmOptimizer } from "./wasmopt"
 
 function optimize(loss: k.Num, init: Map<k.Param, number>, iterations: number) {
-  const params = wasmOptimizer(loss, g.gradient(loss), init).optimize(
-    iterations,
-  )
+  const optimizeImpl = wasmOptimizer(loss, g.gradient(loss))
+  const params = optimizeImpl(init, new Map(), iterations)
   return {
     evaluate(p: k.Param) {
       return checkNotNull(params.get(p))

--- a/src/core/wasmopt.test.ts
+++ b/src/core/wasmopt.test.ts
@@ -7,13 +7,13 @@ import * as g from "./grad"
 import { wasmOptimizer } from "./wasmopt"
 
 function optimize(
-    loss: k.Num,
-    init: Map<k.Param, number>,
-    iterations: number,
-    observations: Map<k.Param, number> = new Map()
-  ): e.Evaluator {
-  const optimizeImpl = wasmOptimizer(loss, g.gradient(loss))
-  const params = optimizeImpl(init, observations, iterations)
+  loss: k.Num,
+  init: Map<k.Param, number>,
+  iterations: number,
+  observations: Map<k.Param, number> = new Map(),
+) {
+  const optimizeImpl = wasmOptimizer(loss, g.gradient(loss), init)
+  const params = optimizeImpl(iterations, observations)
   return {
     evaluate(p: k.Param) {
       return checkNotNull(params.get(p))
@@ -39,5 +39,7 @@ test("free and fixed params", () => {
   const ev = optimize(loss, new Map([[x, 0.1]]), 100, new Map([[y, 1]]))
   expect(ev.evaluate(x)).toBeCloseTo(0, 2)
 
-  expect(() => optimize(loss, new Map([[x, 0.1]]), 100)).toThrowError(/Missing observation 'y'/)
+  expect(() => optimize(loss, new Map([[x, 0.1]]), 100)).toThrowError(
+    /Missing observation 'y'/,
+  )
 })

--- a/src/core/wasmopt.test.ts
+++ b/src/core/wasmopt.test.ts
@@ -6,9 +6,14 @@ import * as g from "./grad"
 
 import { wasmOptimizer } from "./wasmopt"
 
-function optimize(loss: k.Num, init: Map<k.Param, number>, iterations: number) {
+function optimize(
+    loss: k.Num,
+    init: Map<k.Param, number>,
+    iterations: number,
+    observations: Map<k.Param, number> = new Map()
+  ): e.Evaluator {
   const optimizeImpl = wasmOptimizer(loss, g.gradient(loss))
-  const params = optimizeImpl(init, new Map(), iterations)
+  const params = optimizeImpl(init, observations, iterations)
   return {
     evaluate(p: k.Param) {
       return checkNotNull(params.get(p))
@@ -23,4 +28,16 @@ test("simple case with one param", () => {
   // Start close to the solution (0) and run for only a few iterations.
   const ev = optimize(loss, new Map([[x, 0.1]]), 100)
   expect(ev.evaluate(x)).toBeCloseTo(0, 2)
+})
+
+test("free and fixed params", () => {
+  const x = k.param("x")
+  const y = k.observation("y")
+  let loss = k.add(k.pow(x, 2), y)
+
+  // Start close to the solution (1) and run for only a few iterations.
+  const ev = optimize(loss, new Map([[x, 0.1]]), 100, new Map([[y, 1]]))
+  expect(ev.evaluate(x)).toBeCloseTo(0, 2)
+
+  expect(() => optimize(loss, new Map([[x, 0.1]]), 100)).toThrowError(/Missing observation 'y'/)
 })

--- a/src/core/wasmopt.ts
+++ b/src/core/wasmopt.ts
@@ -114,7 +114,7 @@ export function wasmOptimizer(loss: t.Num, gradient: Map<t.Param, t.Num>) {
     const paramEntries = [
       ...freeParams,
       ...fixedParams.map((p): [t.Param, number] => {
-        assert(observations.has(p), `missing observation '${p.name}'`)
+        assert(observations.has(p), `Missing observation '${p.name}'`)
         return [p, checkNotNull(observations.get(p))]
       }),
     ]

--- a/src/turtle/turtle.ts
+++ b/src/turtle/turtle.ts
@@ -87,10 +87,19 @@ export class Turtle {
     this.direction = v.addAngles(this.direction, angle)
   }
 
-  optimize(iterations: number) {
-    const ev = k.optimize(this.loss, this.params, iterations)
-    this.params = ev.params
-  }
+  optimize: (iterations: number) => void = (() => {
+    // Reuse the optimizer as long as the loss function is unchanged.
+    let currLoss: k.Num
+    let opt: k.Optimizer
+    return (iterations) => {
+      if (!currLoss || this.loss !== currLoss) {
+        opt = k.optimizer(this.loss, this.params)
+        currLoss = this.loss
+      }
+      const ev = opt.optimize(iterations)
+      this.params = ev.params
+    }
+  })()
 
   segments(): Array<Segment> {
     const ev = k.evaluator(this.params)

--- a/src/turtle/turtle.ts
+++ b/src/turtle/turtle.ts
@@ -34,6 +34,9 @@ export class Turtle {
     unpinnedLoss: k.Num
   }
 
+  private prevLoss?: k.Num
+  private optimizer?: k.Optimizer
+
   constructor() {
     this.loss = k.zero
     this.vecSegments = []
@@ -87,19 +90,15 @@ export class Turtle {
     this.direction = v.addAngles(this.direction, angle)
   }
 
-  optimize: (iterations: number) => void = (() => {
+  optimize(iterations: number): void {
     // Reuse the optimizer as long as the loss function is unchanged.
-    let currLoss: k.Num
-    let opt: k.Optimizer
-    return (iterations) => {
-      if (!currLoss || this.loss !== currLoss) {
-        opt = k.optimizer(this.loss, this.params)
-        currLoss = this.loss
-      }
-      const ev = opt.optimize(iterations)
-      this.params = ev.params
+    if (!this.optimizer || this.loss !== this.prevLoss) {
+      this.optimizer = k.optimizer(this.loss, this.params)
+      this.prevLoss = this.loss
     }
-  })()
+    const ev = this.optimizer.optimize(iterations)
+    this.params = ev.params
+  }
 
   segments(): Array<Segment> {
     const ev = k.evaluator(this.params)


### PR DESCRIPTION
- Add an `optimizer` function, which returns an object on which `optimize` can be called repeatedly with different observations. Initial parameter values are specified when creating the optimizer; only observations can be passed to `optimize`.
- Turtle now reuses the optimizer where possible (i.e., if the loss function hasn't changed)