### PR TITLE
Low-level IR with pretty printing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "assemblyscript": "^0.27.11",
         "assemblyscript-prettier": "^3.0.1",
         "husky": "^8.0.3",
-        "tiny-dedent": "^1.0.2",
+        "ts-dedent": "^2.2.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.2",
         "vite": "^4.4.5",
@@ -1320,17 +1320,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/core-js": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
-      "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -2206,18 +2195,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tiny-dedent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-dedent/-/tiny-dedent-1.0.2.tgz",
-      "integrity": "sha512-YhfDUk2ATCuMjyeWxueoOvZGG6czpiB/rCcS12DKvDYRZRWFZ3EpZetTd9R54H6bKpJa0W7IJ6sjFbtJatWIOQ==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.19.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.1.tgz",
@@ -2240,6 +2217,15 @@
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "assemblyscript": "^0.27.11",
     "assemblyscript-prettier": "^3.0.1",
     "husky": "^8.0.3",
+    "ts-dedent": "^2.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",

--- a/src/core/wasm/instr.test.ts
+++ b/src/core/wasm/instr.test.ts
@@ -1,0 +1,88 @@
+import * as w from "@wasmgroundup/emit"
+import { dedent } from "ts-dedent"
+import { expect, test } from "vitest"
+
+import * as prebuilt from "../../../build/release.wasm_sections"
+import { builtins } from "./builtins"
+import * as i from "./instr"
+
+const powIdx =
+  builtins.findIndex((fn) => fn.name === "pow") + prebuilt.importsec.entryCount
+
+test("prettyPrint: const", () => {
+  expect(i.prettyPrint(i.f64_const("x", 99))).toEqual("f64.const 99")
+  expect(i.prettyPrint(i.f64_const("x", 12345.678))).toEqual(
+    "f64.const 12345.678",
+  )
+})
+
+test("binary", () => {
+  const l = i.f64_const("x", 123.456)
+  const r = i.f64_const("x", 99)
+  expect(i.prettyPrint(i.f64_binOp("x", "add", l, r))).toEqual(dedent`
+    f64.const 123.456
+    f64.const 99
+    f64.add
+  `)
+
+  expect(i.toBytes(i.f64_binOp("x", "add", l, r))).toEqual(
+    [
+      [w.instr.f64.const, w.f64(123.456)],
+      [w.instr.f64.const, w.f64(99)],
+      w.instr.f64.add,
+    ].flat(2),
+  )
+})
+
+test("prettyPrint: load", () => {
+  expect(i.prettyPrint(i.f64_load("x", 99))).toEqual(dedent`
+    i32.const 99
+    f64.load {3,0}
+  `)
+})
+
+test("prettyPrint: store", () => {
+  const store = i.f64_store("x", 99, i.f64_const("y", 123.456))
+  expect(i.prettyPrint(store)).toEqual(dedent`
+    i32.const 99
+    f64.const 123.456
+    f64.store {3,0}
+  `)
+})
+
+test("prettyPrint: call", () => {
+  expect(i.prettyPrint(i.callBuiltin("x", "pow"))).toEqual(dedent`
+    call $${powIdx} (pow)
+  `)
+})
+
+test("toBytes: const", () => {
+  expect(i.toBytes(i.f64_const("x", 99))).toEqual([
+    0x44, 0, 0, 0, 0, 0, 192, 88, 64,
+  ])
+  //    expect(i.toBytes(i.f64_const("x", 12345.678))).toEqual("f64.const 12345.678")
+})
+test("toBytes: load", () => {
+  expect(i.toBytes(i.f64_load("x", 99))).toEqual(
+    [
+      [w.instr.i32.const, w.i32(99)],
+      [w.instr.f64.load, [3, 0]],
+    ].flat(2),
+  )
+})
+test("toBytes: store", () => {
+  const store = i.f64_store("x", 99, i.f64_const("y", 123.456))
+  expect(i.toBytes(store)).toEqual(
+    [
+      [w.instr.i32.const, w.i32(99)],
+      [w.instr.f64.const, w.f64(123.456)],
+      [w.instr.f64.store, [3, 0]],
+    ].flat(2),
+  )
+})
+test("toBytes: call", () => {
+  expect(i.toBytes(i.callBuiltin("x", "pow"))).toEqual([
+    w.instr.call,
+    ...w.funcidx(powIdx),
+  ])
+})

--- a/src/core/wasm/instr.test.ts
+++ b/src/core/wasm/instr.test.ts
@@ -41,11 +41,12 @@ test("binary", () => {
 })
 
 test("load", () => {
-  expect(i.prettyPrint(i.f64_load(null, 99))).toEqual(dedent`
+  const load = i.f64_load(null, 99)
+  expect(i.prettyPrint(load)).toEqual(dedent`
     i32.const 99
     f64.load {3,0}
   `)
-  expect(i.toBytes(i.f64_load(null, 99))).toEqual(
+  expect(i.toBytes(load)).toEqual(
     [
       [w.instr.i32.const, w.i32(99)],
       [w.instr.f64.load, [3, 0]],
@@ -69,10 +70,26 @@ test("store", () => {
   )
 })
 
-test("prettyPrint: call", () => {
+test("call", () => {
   const call = i.callBuiltin(null, "pow")
   expect(i.prettyPrint(call)).toEqual(dedent`
     call $${powIdx} (pow)
   `)
   expect(i.toBytes(call)).toEqual([w.instr.call, ...w.funcidx(powIdx)])
+})
+
+test("prettyPrint - seq with source", () => {
+  const load = i.f64_load("load!", 99)
+  const store = i.f64_store("store!", 99, i.f64_const("y", 123.456))
+  const seq = i.seq("brrrr", load, store)
+  expect(i.prettyPrint(seq)).toEqual(dedent`
+    (; brrrr ;)
+    (; load! ;)
+    i32.const 99
+    f64.load {3,0}
+    (; store! ;)
+    i32.const 99
+    f64.const 123.456
+    f64.store {3,0}
+  `)
 })

--- a/src/core/wasm/instr.test.ts
+++ b/src/core/wasm/instr.test.ts
@@ -9,23 +9,29 @@ import * as i from "./instr"
 const powIdx =
   builtins.findIndex((fn) => fn.name === "pow") + prebuilt.importsec.entryCount
 
-test("prettyPrint: const", () => {
-  expect(i.prettyPrint(i.f64_const("x", 99))).toEqual("f64.const 99")
-  expect(i.prettyPrint(i.f64_const("x", 12345.678))).toEqual(
+test("const", () => {
+  expect(i.prettyPrint(i.f64_const(null, 99))).toEqual("f64.const 99")
+  expect(i.prettyPrint(i.f64_const(null, 12345.678))).toEqual(
     "f64.const 12345.678",
   )
+
+  expect(i.toBytes(i.f64_const(null, 99))).toEqual([
+    0x44, 0, 0, 0, 0, 0, 192, 88, 64,
+  ])
 })
 
 test("binary", () => {
-  const l = i.f64_const("x", 123.456)
-  const r = i.f64_const("x", 99)
-  expect(i.prettyPrint(i.f64_binOp("x", "add", l, r))).toEqual(dedent`
+  const l = i.f64_const(null, 123.456)
+  const r = i.f64_const(null, 99)
+  const bin = i.f64_binOp(null, "add", l, r)
+
+  expect(i.prettyPrint(bin)).toEqual(dedent`
     f64.const 123.456
     f64.const 99
     f64.add
   `)
 
-  expect(i.toBytes(i.f64_binOp("x", "add", l, r))).toEqual(
+  expect(i.toBytes(bin)).toEqual(
     [
       [w.instr.f64.const, w.f64(123.456)],
       [w.instr.f64.const, w.f64(99)],
@@ -34,44 +40,26 @@ test("binary", () => {
   )
 })
 
-test("prettyPrint: load", () => {
-  expect(i.prettyPrint(i.f64_load("x", 99))).toEqual(dedent`
+test("load", () => {
+  expect(i.prettyPrint(i.f64_load(null, 99))).toEqual(dedent`
     i32.const 99
     f64.load {3,0}
   `)
-})
-
-test("prettyPrint: store", () => {
-  const store = i.f64_store("x", 99, i.f64_const("y", 123.456))
-  expect(i.prettyPrint(store)).toEqual(dedent`
-    i32.const 99
-    f64.const 123.456
-    f64.store {3,0}
-  `)
-})
-
-test("prettyPrint: call", () => {
-  expect(i.prettyPrint(i.callBuiltin("x", "pow"))).toEqual(dedent`
-    call $${powIdx} (pow)
-  `)
-})
-
-test("toBytes: const", () => {
-  expect(i.toBytes(i.f64_const("x", 99))).toEqual([
-    0x44, 0, 0, 0, 0, 0, 192, 88, 64,
-  ])
-  //    expect(i.toBytes(i.f64_const("x", 12345.678))).toEqual("f64.const 12345.678")
-})
-test("toBytes: load", () => {
-  expect(i.toBytes(i.f64_load("x", 99))).toEqual(
+  expect(i.toBytes(i.f64_load(null, 99))).toEqual(
     [
       [w.instr.i32.const, w.i32(99)],
       [w.instr.f64.load, [3, 0]],
     ].flat(2),
   )
 })
-test("toBytes: store", () => {
-  const store = i.f64_store("x", 99, i.f64_const("y", 123.456))
+
+test("store", () => {
+  const store = i.f64_store(null, 99, i.f64_const("y", 123.456))
+  expect(i.prettyPrint(store)).toEqual(dedent`
+    i32.const 99
+    f64.const 123.456
+    f64.store {3,0}
+  `)
   expect(i.toBytes(store)).toEqual(
     [
       [w.instr.i32.const, w.i32(99)],
@@ -80,9 +68,11 @@ test("toBytes: store", () => {
     ].flat(2),
   )
 })
-test("toBytes: call", () => {
-  expect(i.toBytes(i.callBuiltin("x", "pow"))).toEqual([
-    w.instr.call,
-    ...w.funcidx(powIdx),
-  ])
+
+test("prettyPrint: call", () => {
+  const call = i.callBuiltin(null, "pow")
+  expect(i.prettyPrint(call)).toEqual(dedent`
+    call $${powIdx} (pow)
+  `)
+  expect(i.toBytes(call)).toEqual([w.instr.call, ...w.funcidx(powIdx)])
 })

--- a/src/core/wasm/instr.ts
+++ b/src/core/wasm/instr.ts
@@ -3,30 +3,200 @@ import * as w from "@wasmgroundup/emit"
 import * as prebuilt from "../../../build/release.wasm_sections"
 import { builtins } from "./builtins"
 
+export enum WasmType {
+  Binary,
+  Const,
+  Load,
+  Store,
+  Call,
+  Seq,
+}
+
+export type WasmInstr<T> =
+  | BinaryInstr<T>
+  | ConstInstr<T>
+  | LoadInstr<T>
+  | StoreInstr<T>
+  | CallInstr<T>
+export type WasmFragment<T> = WasmInstr<T> | WasmInstrSeq<T>
+
+export interface WasmInstrSeq<T> {
+  type: WasmType.Seq
+  source: T
+  instrs: WasmFragment<T>[]
+}
+
+export interface BinaryInstr<T> {
+  type: WasmType.Binary
+  source: T
+  valtype: "i32" | "f64"
+  op: "mul" | "add"
+
+  // These must be WasmFragment, and not WasmInstr, in order to handle calls
+  // that take arguments.
+  l: WasmFragment<T>
+  r: WasmFragment<T>
+}
+
+export interface ConstInstr<T> {
+  type: WasmType.Const
+  source: T
+  valtype: "i32" | "f64"
+  value: number
+}
+
+export interface LoadInstr<T> {
+  type: WasmType.Load
+  source: T
+  valtype: "f64"
+  addr: WasmInstr<T>
+}
+
+export interface StoreInstr<T> {
+  type: WasmType.Store
+  source: T
+  valtype: "f64"
+  addr: WasmInstr<T>
+  // This must be WasmFragment, and not WasmInstr, in order to handle calls
+  // that take arguments.
+  expr: WasmFragment<T>
+}
+
+export interface CallInstr<T> {
+  type: WasmType.Call
+  source: T
+  funcidx: number
+  name: string
+}
+
 // Required as an immediate arg for all loads/stores.
-const ALIGNMENT_AND_OFFSET = w.memarg(3 /* bits */, 0)
+const ALIGNMENT_AND_OFFSET: number[] = w.memarg(3 /* bits */, 0).flat(1)
 
-export function callBuiltin(name: string): w.BytecodeFragment {
-  const idx = builtins.findIndex((fn) => fn.name === name)
+export function callBuiltin<T>(source: T, name: string): CallInstr<T> {
+  const idx =
+    builtins.findIndex((fn) => fn.name === name) + prebuilt.importsec.entryCount
   if (idx === -1) throw new Error(`builtin '${name}' not found`)
-  return [w.instr.call, w.funcidx(prebuilt.importsec.entryCount + idx)]
+  return {
+    type: WasmType.Call,
+    source,
+    funcidx: idx,
+    name,
+  }
 }
 
-export function f64_const(v: number) {
-  return [w.instr.f64.const, w.f64(v)]
+export function i32_const<T>(source: T, v: number): ConstInstr<T> {
+  return { type: WasmType.Const, source, valtype: "i32", value: v }
 }
 
-export function f64_load(offset: number) {
-  return [
-    [w.instr.i32.const, w.i32(offset)],
-    [w.instr.f64.load, ALIGNMENT_AND_OFFSET],
-  ]
+export function f64_const<T>(source: T, v: number): ConstInstr<T> {
+  return { type: WasmType.Const, source, valtype: "f64", value: v }
 }
 
-export function f64_store(offset: number, frag: w.BytecodeFragment) {
-  return [
-    [w.instr.i32.const, w.i32(offset)],
-    frag,
-    [w.instr.f64.store, ALIGNMENT_AND_OFFSET],
-  ]
+export function f64_binOp<T>(
+  source: T,
+  op: BinaryInstr<T>["op"],
+  l: WasmFragment<T>,
+  r: WasmFragment<T>,
+): BinaryInstr<T> {
+  return {
+    type: WasmType.Binary,
+    source,
+    valtype: "f64",
+    op,
+    l,
+    r,
+  }
+}
+
+export function f64_load<T>(source: T, offset: number): LoadInstr<T> {
+  return {
+    type: WasmType.Load,
+    source,
+    valtype: "f64",
+    // TODO: What to do about source?
+    addr: i32_const<T>(source, offset),
+  }
+}
+
+export function f64_store<T>(
+  source: T,
+  offset: number,
+  expr: WasmFragment<T>,
+): StoreInstr<T> {
+  return {
+    type: WasmType.Store,
+    source,
+    valtype: "f64",
+    addr: i32_const<T>(source, offset),
+    expr,
+  }
+}
+
+export function seq<T>(
+  source: T,
+  ...instrs: WasmFragment<T>[]
+): WasmInstrSeq<T> {
+  return {
+    type: WasmType.Seq,
+    source,
+    instrs,
+  }
+}
+
+export function prettyPrint<T>(frag: WasmFragment<T>): string {
+  switch (frag.type) {
+    case WasmType.Const:
+      return `${frag.valtype}.const ${frag.value}`
+    case WasmType.Binary:
+      return [
+        prettyPrint(frag.l),
+        prettyPrint(frag.r),
+        `${frag.valtype}.${frag.op}`,
+      ].join("\n")
+    case WasmType.Load:
+      return [
+        prettyPrint(frag.addr),
+        `${frag.valtype}.load {${ALIGNMENT_AND_OFFSET}}`,
+      ].join("\n")
+    case WasmType.Store:
+      return [
+        prettyPrint(frag.addr),
+        prettyPrint(frag.expr),
+        `${frag.valtype}.store {${ALIGNMENT_AND_OFFSET}}`,
+      ].join("\n")
+    case WasmType.Call:
+      return `call $${frag.funcidx} (${frag.name})`
+    case WasmType.Seq:
+      return frag.instrs.flatMap(prettyPrint).join("\n")
+  }
+}
+
+export function toBytes<T>(frag: WasmFragment<T>): number[] {
+  switch (frag.type) {
+    case WasmType.Const:
+      return frag.valtype === "f64"
+        ? [w.instr.f64.const, ...w.f64(frag.value)]
+        : [w.instr.i32.const, ...w.i32(frag.value)]
+    case WasmType.Binary:
+      return [
+        toBytes(frag.l),
+        toBytes(frag.r),
+        w.instr[frag.valtype][frag.op],
+      ].flat(3)
+    case WasmType.Load:
+      return [
+        toBytes(frag.addr),
+        [w.instr.f64.load, ALIGNMENT_AND_OFFSET],
+      ].flat(3)
+    case WasmType.Store:
+      return [
+        toBytes(frag.addr),
+        toBytes(frag.expr),
+        [w.instr.f64.store, ALIGNMENT_AND_OFFSET],
+      ].flat(3)
+    case WasmType.Call:
+      return [w.instr.call, ...w.funcidx(frag.funcidx)]
+    case WasmType.Seq:
+      return frag.instrs.flatMap(toBytes)
+  }
 }

--- a/src/core/wasm/instr.ts
+++ b/src/core/wasm/instr.ts
@@ -116,8 +116,7 @@ export function f64_load(source: FragmentSource, offset: number): LoadInstr {
     type: WasmType.Load,
     source,
     valtype: "f64",
-    // TODO: What to do about source?
-    addr: i32_const(source, offset),
+    addr: i32_const(null, offset),
   }
 }
 
@@ -130,7 +129,7 @@ export function f64_store(
     type: WasmType.Store,
     source,
     valtype: "f64",
-    addr: i32_const(source, offset),
+    addr: i32_const("store addr", offset),
     expr,
   }
 }

--- a/src/core/wasmopt.ts
+++ b/src/core/wasmopt.ts
@@ -96,10 +96,6 @@ export function wasmOptimizer(loss: Loss, init: Map<t.Param, number>) {
     body: i.toBytes(visitIrNode(node, ctx)),
   }))
 
-  ;[mod.loss, ...gradientNodes].map((node) =>
-    console.log(i.prettyPrint(visitIrNode(node, ctx))),
-  )
-
   const cache = new OptimizerCache(ctx.cacheEntries)
 
   // Initialize the cache with values for the free params.


### PR DESCRIPTION
- Introduce a low-level representation that corresponds to Wasm instructions.
- Nodes can be associated with an `Expr` in the high-level IR or an arbitrary string.
- `prettyPrint` prints instructions in a format very similar to the WebAssembly text format (.wat), with source info (the `Expr` or string) included as comments
- `toBytes` converts to a `number[]` representing the raw bytecode stream

Example:

```
const load = i.f64_load("brilliant load", 99)
const store = i.f64_store("amazing store", 99, i.f64_const("y", 123.456))
const seq = i.seq("brrrr", load, store)
expect(i.prettyPrint(seq)).toEqual(dedent`
  (; brrrr ;)
  (; brilliant load ;)
  i32.const 99
  f64.load {3,0}
  (; amazing store ;)
  i32.const 99
  f64.const 123.456
  f64.store {3,0}
`)
```

TODOs for future PRs:
- [ ] Update handling of `KOMBU_DEBUG` so that you can use that var to dump instructions
- [ ] Improve formatting of comments to make it easy to align with high-level IR. Maybe show nesting depth?