### PR TITLE
Reland optimization to use `-` where appropriate

### DIFF
--- a/src/core/ir.test.ts
+++ b/src/core/ir.test.ts
@@ -43,3 +43,50 @@ describe("pseudocode", () => {
     )
   })
 })
+
+function checkBinary(exp: ir.Expr): ir.BinaryExpr {
+  if (exp.type !== ir.ExprType.Binary) throw new Error("not a Binary")
+  return exp as ir.BinaryExpr
+}
+
+const toIR = (num: k.Num) => ir.module(loss(num)).loss
+
+test("simplification - plus", () => {
+  const x = k.param("x")
+  const y = k.param("y")
+
+  // x - 3
+  let exp = toIR(k.sub(x, 3))
+  expect(exp.type).toBe(ir.ExprType.Binary)
+  expect(checkBinary(exp).op).toBe("-")
+
+  // 3 - x
+  exp = toIR(k.sub(3, k.param("x")))
+  expect(exp.type).toBe(ir.ExprType.Binary)
+  expect(checkBinary(exp).op).toBe("-")
+
+  // -1x + y => y - x
+  exp = toIR(k.add(k.mul(-1, x), y))
+  expect(exp).toEqual(ir.binary("-", ir.param(y), ir.param(x)))
+
+  // x + (-1y + 3) => (x - y) + 3
+  exp = toIR(k.add(x, k.add(k.mul(-1, y), 3)))
+  expect(exp).toEqual(
+    ir.binary("+", ir.binary("-", ir.param(x), ir.param(y)), ir.constant(3)),
+  )
+})
+
+test("simplification - neg exponents", () => {
+  const x = k.param("x")
+  const y = k.param("y")
+
+  // 2 * y^-1 + x = 2/y + x
+  let exp = toIR(k.add(k.mul(2, k.pow(y, -1)), x))
+  expect(exp).toEqual(
+    ir.binary("+", ir.binary("/", ir.constant(2), ir.param(y)), ir.param(x)),
+  )
+
+  // 3 * x^-1 = 3/x
+  exp = toIR(k.mul(3, k.pow(x, -1)))
+  expect(exp).toEqual(ir.binary("/", ir.constant(3), ir.param(x)))
+})

--- a/src/core/ir.test.ts
+++ b/src/core/ir.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest"
 import * as k from "./api"
 import * as ir from "./ir"
 import { loss } from "./loss"
+import { DEBUG_logIrModule } from "./debug"
 
 describe("lisp", () => {
   test("simple case with one param", () => {
@@ -49,7 +50,11 @@ function checkBinary(exp: ir.Expr): ir.BinaryExpr {
   return exp as ir.BinaryExpr
 }
 
-const toIR = (num: k.Num) => ir.module(loss(num)).loss
+const toIR = (num: k.Num) => {
+  const mod = ir.module(loss(num))
+  DEBUG_logIrModule(mod)
+  return mod.loss
+}
 
 test("simplification - plus", () => {
   const x = k.param("x")

--- a/src/core/wasm/instr.ts
+++ b/src/core/wasm/instr.ts
@@ -33,7 +33,7 @@ export interface BinaryInstr {
   type: WasmType.Binary
   source: FragmentSource
   valtype: "i32" | "f64"
-  op: "mul" | "add"
+  op: "mul" | "div" | "add" | "sub"
 
   // These must be WasmFragment, and not WasmInstr, in order to handle calls
   // that take arguments.
@@ -196,11 +196,12 @@ export function toBytes(frag: WasmFragment): number[] {
         ? [w.instr.f64.const, ...w.f64(frag.value)]
         : [w.instr.i32.const, ...w.i32(frag.value)]
     case WasmType.Binary:
-      return [
-        toBytes(frag.l),
-        toBytes(frag.r),
-        w.instr[frag.valtype][frag.op],
-      ].flat(3)
+      if (frag.valtype === "f64" || frag.op !== "div") {
+        return [toBytes(frag.l), toBytes(frag.r), w.instr["f64"][frag.op]].flat(
+          3,
+        )
+      }
+      throw new Error(`unhandled: ${frag.valtype}.${frag.op}`)
     case WasmType.Load:
       return [
         toBytes(frag.addr),

--- a/src/core/wasmopt.test.ts
+++ b/src/core/wasmopt.test.ts
@@ -95,3 +95,15 @@ test("loss function with abs()", () => {
   let ev = optimize(value, new Map([[a, 8]]), maxIterations)
   expect(ev.evaluate(a)).toBeCloseTo(0, 2)
 })
+
+test("div", () => {
+  const x = k.param("x")
+  const y = k.observation("y")
+  const loss = k.add(k.pow(x, 2), k.div(2, y))
+
+  const obs = new Map([[y, 1]])
+
+  // Start close to the solution (0) and run for only a few iterations.
+  const ev = optimize(loss, new Map([[x, 0.1]]), 100, obs)
+  expect(ev.evaluate(x)).toBeCloseTo(0, 2)
+})

--- a/src/core/wasmopt.ts
+++ b/src/core/wasmopt.ts
@@ -183,8 +183,16 @@ export function wasmOptimizer(loss: Loss, init: Map<t.Param, number>) {
     if (node.op === "pow") {
       return i.seq(node, lfrag, rfrag, i.callBuiltin(null, "pow"))
     }
-    const instr = node.op === "+" ? "add" : "mul"
-    return i.f64_binOp(node, instr, lfrag, rfrag)
+    switch (node.op) {
+      case "+":
+        return i.f64_binOp(node, "add", lfrag, rfrag)
+      case "-":
+        return i.f64_binOp(node, "sub", lfrag, rfrag)
+      case "*":
+        return i.f64_binOp(node, "mul", lfrag, rfrag)
+      case "/":
+        return i.f64_binOp(node, "div", lfrag, rfrag)
+    }
   }
 
   return optimize


### PR DESCRIPTION
- Reland the simplification/optimization to use `-` where appropriate.
- Avoid the bug with shared subexpressions, where the compute+store gets moved after the load.
- TODO for a future PR: use `combineTerms` for `ProductTerms` as well.