### PR TITLE
Add option to use plain gradient descent

### DIFF
--- a/assembly/asopt.ts
+++ b/assembly/asopt.ts
@@ -42,8 +42,10 @@ export function optimizeGradientDescent(
 ): void {
   for (let i: uint = 0; i < maxIterations; i++) {
     u.evaluateLoss()
-    for (let i: uint = 0; i < numFreeParams; i++) {
-      u.setParam(i, u.getParam(i) - learningRate * u.evaluateGradient(i))
+
+    for (let j: uint = 0; j < numFreeParams; j++) {
+      const g = u.evaluateGradient(j)
+      u.setParam(j, u.getParam(j) - learningRate * g)
     }
   }
 }

--- a/assembly/asopt.ts
+++ b/assembly/asopt.ts
@@ -2,7 +2,7 @@ import { init, apply } from "./lbfgs"
 import * as u from "./util"
 import { double, uint } from "./types"
 
-export function optimize(
+export function optimizeLBFGS(
   numFreeParams: uint,
   maxIterations: uint,
   m: uint,
@@ -31,6 +31,19 @@ export function optimize(
     // Copy params back out.
     for (let i: uint = 0; i < numFreeParams; i++) {
       u.setParam(i, x[i])
+    }
+  }
+}
+
+export function optimizeGradientDescent(
+  numFreeParams: uint,
+  maxIterations: uint,
+  learningRate: double,
+): void {
+  for (let i: uint = 0; i < maxIterations; i++) {
+    u.evaluateLoss()
+    for (let i: uint = 0; i < numFreeParams; i++) {
+      u.setParam(i, u.getParam(i) - learningRate * u.evaluateGradient(i))
     }
   }
 }

--- a/src/core/debug.ts
+++ b/src/core/debug.ts
@@ -11,6 +11,7 @@ const channels: Set<string> = new Set(
 
 const DEBUG_WASM = channels.has("wasm")
 const DEBUG_IR = channels.has("ir")
+const DEBUG_RANDOM = channels.has("random")
 
 const now = () => new Date().getTime()
 
@@ -39,4 +40,8 @@ export function DEBUG_logWasm(funcidx: number, code: i.WasmFragment) {
   if (!DEBUG_WASM) return
   console.log(`\n[function #${funcidx}]`)
   console.log(i.prettyPrint(code))
+}
+
+export function DEBUG_useDeterministicRNG() {
+  return DEBUG_RANDOM
 }

--- a/src/core/optimize.ts
+++ b/src/core/optimize.ts
@@ -33,7 +33,7 @@ export function optimizer(
     if (!freeParams.has(p)) freeParams.set(p, standardNormalRandom())
   })
 
-  // The internal optimizer inteface is similar to the public API, but we
+  // The internal optimizer interface is similar to the public API, but we
   // assume that param values are fully specified.
   let optimizeImpl = (useWasm ? wasmOptimizer : jsOptimizer)(loss, freeParams)
 

--- a/src/core/optimize.ts
+++ b/src/core/optimize.ts
@@ -1,9 +1,10 @@
 import { assert } from "./assert"
+import { DEBUG_useDeterministicRNG } from "./debug"
 import * as e from "./eval"
 import { jsOptimizer } from "./jsopt"
 import { Loss } from "./loss"
 import * as t from "./types"
-import { wasmOptimizer, OptimizeOptions } from "./wasmopt"
+import { OptimizeOptions, wasmOptimizer } from "./wasmopt"
 
 export type { OptimizeOptions } from "./wasmopt"
 
@@ -15,10 +16,25 @@ export interface Optimizer {
   ): e.Evaluator
 }
 
+// https://en.wikipedia.org/wiki/Linear_congruential_generator
+function lcg(x0: number) {
+  // Use same params as ANSI C.
+  const m = 2 ** 32
+  const a = 1103515245
+  const c = 12345
+  let x = x0
+  return () => {
+    x = (a * x + c) % m
+    return x / m
+  }
+}
+
+// Use our own random number generation, since Math.random() can't be seeded.
+const random = lcg(DEBUG_useDeterministicRNG() ? 853570741 : Date.now() % 1e9)
+
 function standardNormalRandom() {
   return (
-    Math.sqrt(-2 * Math.log(1 - Math.random())) *
-    Math.cos(2 * Math.PI * Math.random())
+    Math.sqrt(-2 * Math.log(1 - random())) * Math.cos(2 * Math.PI * random())
   )
 }
 

--- a/src/core/wasm/mod.ts
+++ b/src/core/wasm/mod.ts
@@ -2,7 +2,7 @@
 
 import * as w from "@wasmgroundup/emit"
 
-import { checkNotNull } from "../assert"
+import { assert, checkNotNull } from "../assert"
 import { DEBUG_logWasm, DEBUG_writeFile } from "../debug"
 import { builtins } from "./builtins"
 import * as i from "./instr"
@@ -107,9 +107,10 @@ export function instantiateModule(
   functions.forEach(({ name }, i) => {
     if (name) exports.push(w.export_(name, w.exportdesc.func(userFuncIdx(i))))
   })
-  // Export the externally-defined `optimize` function.
-  // TODO: Look up the correct index in the prebuilt module.
-  exports.push(w.export_("optimize", w.exportdesc.func(userFuncIdx(-2))))
+  // Export the externally-defined `optimize` functions.
+  // TODO: Look up the correct indices in the prebuilt module.
+  exports.push(w.export_("optimizeLBFGS", w.exportdesc.func(userFuncIdx(-3))))
+  exports.push(w.export_("optimizeGradientDescent", w.exportdesc.func(userFuncIdx(-2))))
 
   // AssemblyScript's memory manager uses the __heap_base global as the
   // beginning of its heap. Rewrite that value to account for the memory
@@ -192,4 +193,17 @@ export function instantiateModule(
       ...traceImpl(true),
     },
   })
+}
+
+export function callSafely(
+  exports: WebAssembly.Exports,
+  name: string,
+  ...args: number[]
+) {
+  console.log(exports)
+  assert(
+    typeof exports[name] === "function",
+    `export '${name}' not found or not callable`,
+  )
+  ;(exports as any)[name].apply(null, args)
 }

--- a/src/core/wasm/mod.ts
+++ b/src/core/wasm/mod.ts
@@ -110,7 +110,9 @@ export function instantiateModule(
   // Export the externally-defined `optimize` functions.
   // TODO: Look up the correct indices in the prebuilt module.
   exports.push(w.export_("optimizeLBFGS", w.exportdesc.func(userFuncIdx(-3))))
-  exports.push(w.export_("optimizeGradientDescent", w.exportdesc.func(userFuncIdx(-2))))
+  exports.push(
+    w.export_("optimizeGradientDescent", w.exportdesc.func(userFuncIdx(-2))),
+  )
 
   // AssemblyScript's memory manager uses the __heap_base global as the
   // beginning of its heap. Rewrite that value to account for the memory
@@ -200,7 +202,6 @@ export function callSafely(
   name: string,
   ...args: number[]
 ) {
-  console.log(exports)
   assert(
     typeof exports[name] === "function",
     `export '${name}' not found or not callable`,


### PR DESCRIPTION
- Set `useLBFGS = false` in wasmopt.ts to make the optimizer will use gradient descent rather than LBFGS.
- Also add ability to use a predetermined seed for the random number generator, via `KOMBU_DEBUG=random`